### PR TITLE
feat(datagen): add array with fixed values

### DIFF
--- a/crates/datagen-rs/src/plugins/plugin_list.rs
+++ b/crates/datagen-rs/src/plugins/plugin_list.rs
@@ -170,8 +170,16 @@ impl PluginList {
 
     #[cfg(feature = "plugin")]
     fn find_array_transformers(array: &Array) -> Vec<String> {
-        let mut props = Self::find_transformers(&array.items);
-        if let Some(transform) = &array.transform {
+        let mut props = match array {
+            Array::RandomArray(arr) => Self::find_transformers(&arr.items),
+            Array::ArrayWithValues(arr) => arr
+                .values
+                .iter()
+                .flat_map(Self::find_transformers)
+                .collect(),
+        };
+
+        if let Some(transform) = &array.get_transform() {
             props.extend(Self::transformers_to_vec(transform, &props));
         }
 
@@ -242,7 +250,12 @@ impl PluginList {
                 .iter()
                 .flat_map(|(_, val)| Self::find_generators(val))
                 .collect(),
-            AnyValue::Any(Any::Array(arr)) => Self::find_generators(&arr.items),
+            AnyValue::Any(Any::Array(arr)) => match arr.as_ref() {
+                Array::RandomArray(arr) => Self::find_generators(&arr.items),
+                Array::ArrayWithValues(arr) => {
+                    arr.values.iter().flat_map(Self::find_generators).collect()
+                }
+            },
             _ => vec![],
         }
     }

--- a/crates/datagen-rs/src/schema/array.rs
+++ b/crates/datagen-rs/src/schema/array.rs
@@ -17,9 +17,26 @@ pub enum ArrayLength {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct Array {
+#[cfg_attr(feature = "serialize", serde(untagged, deny_unknown_fields))]
+pub enum Array {
+    RandomArray(RandomArray),
+    ArrayWithValues(ArrayWithValues),
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct RandomArray {
     pub length: ArrayLength,
     pub items: AnyValue,
+    pub transform: Option<Vec<Transform>>,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct ArrayWithValues {
+    pub values: Vec<AnyValue>,
     pub transform: Option<Vec<Transform>>,
 }
 
@@ -33,6 +50,8 @@ pub mod generate {
     use crate::schema::transform::Transform;
     use rand::Rng;
     use std::sync::Arc;
+
+    use super::{ArrayWithValues, RandomArray};
 
     impl ArrayLength {
         pub fn get_length(&self) -> u32 {
@@ -51,10 +70,50 @@ pub mod generate {
             self,
             schema: CurrentSchemaRef,
         ) -> anyhow::Result<Arc<GeneratedSchema>> {
+            match self {
+                Array::RandomArray(random_array) => random_array.into_generated_arc(schema),
+                Array::ArrayWithValues(array_with_values) => {
+                    array_with_values.into_generated_arc(schema)
+                }
+            }
+        }
+
+        fn get_transform(&self) -> Option<Vec<Transform>> {
+            match self {
+                Array::RandomArray(random_array) => random_array.get_transform(),
+                Array::ArrayWithValues(array_with_values) => array_with_values.get_transform(),
+            }
+        }
+    }
+
+    impl IntoGeneratedArc for RandomArray {
+        fn into_generated_arc(
+            self,
+            schema: CurrentSchemaRef,
+        ) -> anyhow::Result<Arc<GeneratedSchema>> {
             let length = self.length.get_length();
             schema.map_array(length as _, self.items, None, false, |cur, value| {
                 value.into_random(cur.clone())
             })
+        }
+
+        fn get_transform(&self) -> Option<Vec<Transform>> {
+            self.transform.clone()
+        }
+    }
+
+    impl IntoGeneratedArc for ArrayWithValues {
+        fn into_generated_arc(
+            self,
+            schema: CurrentSchemaRef,
+        ) -> anyhow::Result<Arc<GeneratedSchema>> {
+            Ok(GeneratedSchema::Array(
+                self.values
+                    .into_iter()
+                    .map(|e| e.into_generated_arc(schema.clone()))
+                    .collect::<anyhow::Result<Vec<_>>>()?,
+            )
+            .into())
         }
 
         fn get_transform(&self) -> Option<Vec<Transform>> {

--- a/docs/pages/docs/generators/array.mdx
+++ b/docs/pages/docs/generators/array.mdx
@@ -3,17 +3,23 @@ import RunCode from '../../../components/run/RunCode';
 # array
 
 In order to generate an array, you can use the `array` generator.
-This generator has two inputs:
+This generator has two modes: `random` and `fixed`.
+
+## Random mode
+
+In this mode, the generator will generate an array with either a random or fixed length.
+The items inside the array will be generated using the `items` schema.
+The generator has the following parameters:
 
 - `length`: The length of the array, which is either a fixed or random value
 - `items`: The schema of the items inside the array
 
-## Defining the number of items generated
+### Defining the number of items generated
 
 The `length` parameter is an `object` containing either a fixed `value`
 or a lower and upper length limit to generate a random length between those two values.
 
-### Fixed length
+#### Fixed length
 
 Generate an array with a fixed length of 10 elements:
 
@@ -26,7 +32,7 @@ Generate an array with a fixed length of 10 elements:
 }
 ```
 
-### Random length
+#### Random length
 
 Generate an array with a random length between 5 and 10 elements:
 
@@ -40,7 +46,16 @@ Generate an array with a random length between 5 and 10 elements:
 }
 ```
 
-## Example
+## Fixed mode
+
+In this mode, the generator will generate an array from a fixed list of values.
+The generator has the following parameters:
+
+- `values`: The list of values to generate the array from
+
+## Examples
+
+### Generate an array of strings
 
 Generate an array full of [strings](string.mdx) with a random length:
 
@@ -56,6 +71,60 @@ Generate an array full of [strings](string.mdx) with a random length:
     "type": "string",
     "value": "test"
   }
+}
+```
+</RunCode>
+
+### Generate an array with fixed values
+
+<RunCode>
+```json
+{
+  "type": "array",
+  "values": [
+    "test",
+    "test2",
+    {
+      "type": "number",
+      "precision": 2
+    }
+  ]
+}
+```
+</RunCode>
+
+### Generate an array with fixed values and random values
+
+You can use the [`flatten` generator](./flatten.mdx) in order to
+combine the values of the array generators in order to generate an array with both
+fixed and random values:
+
+<RunCode>
+```json
+{
+  "type": "flatten",
+  "values": [
+    {
+      "type": "array",
+      "values": [
+        "test",
+        "test2"
+      ]
+    },
+    {
+      "type": "array",
+      "length": {
+        "min": 0,
+        "max": 5
+      },
+      "items": {
+        "type": "string",
+        "generator": {
+          "type": "fullName"
+        }
+      }
+    }
+  ]
 }
 ```
 </RunCode>

--- a/docs/pages/docs/transformers.mdx
+++ b/docs/pages/docs/transformers.mdx
@@ -1,3 +1,5 @@
+import RunCode from '../../components/run/RunCode';
+
 # Transformers
 
 Transformers are used to transform data. They are used in the `transform` property of a schema.
@@ -9,6 +11,7 @@ In order to apply a transformer to a value, you need to add the `transform` prop
 to that value. The `transform` property is an array of transformers that will be applied
 to the value in order.
 
+<RunCode>
 ```json
 {
   "type": "string",
@@ -20,6 +23,7 @@ to the value in order.
   ]
 }
 ```
+</RunCode>
 
 Will generate:
 


### PR DESCRIPTION
This PR adds a new array type, which allows to define a fixed set of values:

```json
{
  "type": "array",
  "values": [
    "test",
    "test2",
    {
      "type": "number",
      "precision": 2
    }
  ]
}
```